### PR TITLE
fix: Link to docker hub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run -it --rm -v ~/Desktop:/home/marvin/docker jkutkut/docker4c
 	- libreadline-dev
 
 ## Versions:
-You can see all the containers already created [here](https://hub.docker.com/repository/docker/jkutkut/docker4c/general) or build your own from the code from this repository.
+You can see all the containers already created [here](https://hub.docker.com/r/jkutkut/docker4c) or build your own from the code from this repository.
 ```zsh
 docker run -it --rm -v $(PWD):/home/marvin/docker jkutkut/docker4c:v1.X.X
 ```


### PR DESCRIPTION
Change the link to docker hub 

from: https://hub.docker.com/repository/docker/jkutkut/docker4c/general
to: https://hub.docker.com/r/jkutkut/docker4c

The first one need credentials in DockerHub.